### PR TITLE
feat: get params and query string to replace in url using types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "prepare": "vite build",
     "start": "vite build --watch",
     "test": "vitest run",
+    "test:types": "tsc -p ./tsconfig.test.json",
     "test:watch": "vitest watch",
     "cy": "cypress open",
     "cy:run": "cypress run",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prepack": "pnpm build",
     "prepare": "vite build",
     "start": "vite build --watch",
-    "test": "vitest run",
+    "test": "vitest run && pnpm test:types",
     "test:types": "tsc -p ./tsconfig.test.json",
     "test:watch": "vitest watch",
     "cy": "cypress open",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     }
   },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build; tsc",
     "dev": "vite build --watch",
     "pack": "npm pack --dry-run --pack-destination out out/brouther",
     "prepack": "pnpm build",

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -3,12 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 import { Brouther, } from "../../src";
-import { config } from "./routes";
+import { router } from "./routes";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
         <React.Suspense fallback={<div>Loading...</div>}>
-            <Brouther config={config}>
+            <Brouther config={router.config}>
                 <App />
             </Brouther>
         </React.Suspense>

--- a/playground/src/routes.tsx
+++ b/playground/src/routes.tsx
@@ -5,7 +5,7 @@ import { lazy } from "react";
 
 const Users = lazy(() => import("./pages/users"));
 
-export const { config, ...router } = createMappedRouter({
+export const router = createMappedRouter({
     index: {
         path: "/",
         element: <Root />,
@@ -19,7 +19,7 @@ export const { config, ...router } = createMappedRouter({
         element: <Users />,
     },
     post: {
-        path: "/posts/:id?language=date[]!",
+        path: "/posts/:id?language=number!",
         element: <Users />,
     },
 } as const);
@@ -30,6 +30,6 @@ export const linkToPosts = router.link(
         id: "1",
     },
     {
-        language: [],
-    }
+        language: 5,
+    } as const
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { createRouter } from "./router";
+
 export { createRouter, createMappedRouter } from "./router";
 export { Brouther, useUrlSearchParams, usePage, useNavigation, useErrorPage, usePaths, useQueryString, useHref } from "./brouther";
 export { BroutherError, NotFoundRoute } from "./errors";

--- a/src/router.ts
+++ b/src/router.ts
@@ -7,8 +7,9 @@ import {
     ExtractPaths,
     HasQueryString,
     QueryString,
+    QueryStringMappers,
     ReplaceParams,
-    ReplaceQueryStringValues,
+    ExtractQSValues,
     Route,
     Router,
     UrlParams,
@@ -18,7 +19,7 @@ import { useRouter, useUrlSearchParams } from "./brouther";
 import { createBrowserHistory } from "history";
 import { useMemo } from "react";
 import { RouterNavigator } from "./router-navigator";
-import {Merge} from "ts-toolbelt/out/Union/Merge";
+import { Merge } from "ts-toolbelt/out/Union/Merge";
 
 type Links<T extends readonly Route[], C extends number = 0> = C extends T["length"]
     ? {}
@@ -30,7 +31,7 @@ type __TypeLinkSecondParam<Path extends string> = UrlParams<ExtractPathname<Path
     ? HasQueryString<Path> extends true
         ? QueryString<Path>
         : UrlParams<ExtractPathname<Path>>
-    : {};
+    : QueryString<Path>
 
 type TypeLink<T extends Narrow<Route[]>> = <
     Path extends ExtractPaths<T>,
@@ -39,12 +40,14 @@ type TypeLink<T extends Narrow<Route[]>> = <
 >(
     ...args: Params extends null
         ? HasQueryString<Path> extends true
-            ? [path: Path, qs: QueryString<Path>]
+            ? [path: Path, qs: QS]
             : [path: Path]
         : HasQueryString<Path> extends true
         ? [path: Path, params: Params, qs: QS]
         : [path: Path, params: Params]
-) => Params extends null ? Path : ReplaceQueryStringValues<ReplaceParams<Path, NonNullable<Params>>, NonNullable<QS>>;
+) => Params extends null
+    ? ExtractQSValues<Path, Narrow<NonNullable<QS>>>
+    : ExtractQSValues<ReplaceParams<Path, NonNullable<Params>>, Narrow<NonNullable<QS>>>;
 
 const createLink =
     <T extends Narrow<Route[]>>(_routes: T): TypeLink<T> =>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,19 @@
 import React from "react";
-import { Narrow } from "ts-toolbelt/out/Function/Narrow";
-import type { N, List, O, S, Union } from "ts-toolbelt";
-import { Split } from "ts-toolbelt/out/String/Split";
-import { Add } from "ts-toolbelt/out/Number/Add";
+import type { Number, Function, Object, String, Union } from "ts-toolbelt";
 import { createRouter } from "./router";
 import { RouterNavigator } from "./router-navigator";
-import { Join } from "ts-toolbelt/out/String/Join";
-import { Any } from "ts-toolbelt";
+
+export type Nullable<T> = T | null;
+
+export type Hide<T, K extends keyof T> = Omit<T, K>;
+
+export type QueryStringPrimitive = string | number | null | boolean | QueryStringPrimitive[];
+
+export type Route = {
+    id: Readonly<string>;
+    path: Readonly<string>;
+    element: React.ReactElement;
+};
 
 export type QueryStringMappers = {
     string: string;
@@ -16,13 +23,7 @@ export type QueryStringMappers = {
     null: null;
 };
 
-export type Route = {
-    id: Readonly<string>;
-    path: Readonly<string>;
-    element: React.ReactElement;
-};
-
-export type ExtractPaths<T extends Narrow<Route[]>> = NonNullable<{ [K in keyof T[number]]: T[number]["path"] }["path"]>;
+export type ExtractPaths<T extends Function.Narrow<Route[]>> = NonNullable<{ [K in keyof T[number]]: T[number]["path"] }["path"]>;
 
 export type UrlParams<T extends string> = string extends T
     ? Record<string, string>
@@ -32,9 +33,9 @@ export type UrlParams<T extends string> = string extends T
     ? { [k in Param]: string }
     : null;
 
-export type QueryStringExists<S extends Narrow<string>> = S extends `${string}?${string}` ? true : false;
+export type QueryStringExists<Path extends Function.Narrow<string>> = Path extends `${string}?${string}` ? true : false;
 
-export type AsArray<S extends string> = S extends `${infer R}[]` ? R : S;
+export type AsArray<Type extends string> = Type extends `${infer R}[]` ? R : Type;
 
 export type Mapper<S extends string> = S extends keyof QueryStringMappers
     ? QueryStringMappers[S]
@@ -42,40 +43,34 @@ export type Mapper<S extends string> = S extends keyof QueryStringMappers
     ? QueryStringMappers[AsArray<S>][]
     : S;
 
-export type OnlyQ<S extends string> = S extends `${infer _}?${infer I}` ? I : never;
+export type OnlyQ<Path extends string> = Path extends `${infer _}?${infer I}` ? I : never;
 
 export type Dissemble<Queries extends readonly string[], C extends number = 0> = C extends Queries["length"]
     ? {}
-    : (Split<Queries[C], "=">[1] extends `${infer Value}!`
+    : (String.Split<Queries[C], "=">[1] extends `${infer Value}!`
           ? {
-                [K in Split<Queries[C], "=">[0]]: Mapper<Value>;
+                [K in String.Split<Queries[C], "=">[0]]: Mapper<Value>;
             }
           : {
-                [K in Split<Queries[C], "=">[0]]: Mapper<Split<Queries[C], "=">[1]>;
+                [K in String.Split<Queries[C], "=">[0]]: Mapper<String.Split<Queries[C], "=">[1]>;
             }) &
-          Dissemble<Queries, Add<C, 1>>;
+          Dissemble<Queries, Number.Add<C, 1>>;
 
-export type HasQueryString<S extends string> = OnlyQ<S> extends "" ? false : true;
+export type HasQueryString<Path extends string> = OnlyQ<Path> extends "" ? false : true;
 
-export type QueryString<S extends string> = HasQueryString<S> extends false ? {} : Dissemble<Split<OnlyQ<S>, "&">>;
-
-export type QueryStringPrimitive = string | number | null | boolean | QueryStringPrimitive[];
+export type QueryString<Query extends string> = HasQueryString<Query> extends false ? {} : Dissemble<String.Split<OnlyQ<Query>, "&">>;
 
 export type QueryStringRecord = Record<string, QueryStringPrimitive>;
 
-export type ExtractPathname<S extends string> = Split<S, "?">[0];
-
-export type Nullable<T> = T | null;
+export type ExtractPathname<Path extends string> = String.Split<Path, "?">[0];
 
 export type ConfiguredRoute = Route & { regex: RegExp; originalPath: string };
 
-export type Hide<T, K extends keyof T> = Omit<T, K>;
-
 export type Router = Record<string, Hide<Route, "id">>;
 
-export type ExtractDictPath<T extends Narrow<Router>> = NonNullable<{ [K in keyof T[string]]: T[string]["path"] }["path"]>;
+export type ExtractDictPath<T extends Function.Narrow<Router>> = NonNullable<{ [K in keyof T[string]]: T[string]["path"] }["path"]>;
 
-export type CreateMappedRoute<T extends Narrow<Router>> = {
+export type CreateMappedRoute<T extends Function.Narrow<Router>> = {
     navigator: RouterNavigator;
     config: ReturnType<typeof createRouter<[]>>["config"];
     links: { [K in keyof T]: T[K]["path"] };
@@ -90,23 +85,23 @@ export type CreateMappedRoute<T extends Narrow<Router>> = {
     ) => Params extends null ? Path : ExtractQSValues<ReplaceParams<Path, NonNullable<Params>>, NonNullable<QS>>;
 };
 
-export type ToArray<K extends Record<string, string>> = Union.ListOf<O.UnionOf<{ [k in keyof K]: [k, K[k]] }>>;
+export type ToArray<K extends Record<string, string>> = Union.ListOf<Object.UnionOf<{ [k in keyof K]: [k, K[k]] }>>;
 
-export type ReplaceParams<T extends string, P extends {}, C extends number = 0> = C extends ToArray<P>["length"]
-    ? T
-    : ReplaceParams<S.Replace<T, `:${ToArray<P>[C][0]}`, ToArray<P>[C][1]>, P, N.Add<C, 1>>;
+export type ReplaceParams<Path extends string, Params extends {}, I extends number = 0> = I extends ToArray<Params>["length"]
+    ? Path
+    : ReplaceParams<String.Replace<Path, `:${ToArray<Params>[I][0]}`, ToArray<Params>[I][1]>, Params, Number.Add<I, 1>>;
 
-type Reduce<K extends string, V extends any[], C extends number = 0, Acc extends string[] = []> = C extends V["length"]
-    ? S.Join<Acc, "_">
-    : Reduce<K, V, Add<C, 1>, [...Acc, `${K}=___${V[C]}`]>;
+type Reduce<Key extends string, Value extends any[], I extends number = 0, Acc extends string[] = []> = I extends Value["length"]
+    ? String.Join<Acc, "_">
+    : Reduce<Key, Value, Number.Add<I, 1>, [...Acc, `${Key}=___${Value[I]}`]>;
 
-type ExtractPrimitive<T> = T extends Date | any[] ? any : T;
+type ExtractPrimitive<T> = T extends string | number | symbol ? T : T extends undefined | null ? "" : any;
 
-type BuildQueryStringParam<K extends string, Value extends any[], C extends number = 0, Acc extends string[] = []> = C extends Value["length"]
+type BuildQueryStringParam<Key extends string, Value extends any[], C extends number = 0, Acc extends string[] = []> = C extends Value["length"]
     ? Acc["length"] extends 0
-        ? [`${K}=${ExtractPrimitive<Value>}`]
+        ? [`${Key}=${ExtractPrimitive<Value>}`]
         : Acc
-    : BuildQueryStringParam<K, Value, Add<C, 1>, [...Acc, `${K}=${Value[C]}`]>;
+    : BuildQueryStringParam<Key, Value, Number.Add<C, 1>, [...Acc, `${Key}=${Value[C]}`]>;
 
 type ExtractQueryStringValue<K extends string, Value> = Value extends any[]
     ? BuildQueryStringParam<K, Value>
@@ -127,11 +122,11 @@ type $Replace<
 > = C extends Queries["length"]
     ? Result["length"] extends 0
         ? Path
-        : `${S.Split<Path, "?">[0]}?${S.Join<Result, "&">}`
+        : `${String.Split<Path, "?">[0]}?${String.Join<Result, "&">}`
     : Queries[C] extends `${infer K}=${infer R}`
-    ? $Replace<Path, Queries, Values, Add<C, 1>, [...Result, ...ExtractQueryStringValue<K, Values[K]>]>
-    : $Replace<Path, Queries, Values, Add<C, 1>, [...Result, `KOE=ppp`]>;
+    ? $Replace<Path, Queries, Values, Number.Add<C, 1>, [...Result, ...ExtractQueryStringValue<K, Values[K]>]>
+    : $Replace<Path, Queries, Values, Number.Add<C, 1>, [...Result, `KOE=ppp`]>;
 
 export type ExtractQSValues<Path extends string, Query extends {}> = HasQueryString<Path> extends true
-    ? $Replace<S.Split<Path, "?">[0], S.Split<OnlyQ<Path>, "&">, Query>
+    ? $Replace<String.Split<Path, "?">[0], String.Split<OnlyQ<Path>, "&">, Query>
     : Path;

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,4 +106,4 @@ type __$Replace<T extends readonly string[], O extends Record<string, any>, TXT 
     ? __$Replace<T, O, S.Replace<TXT, T[C], `${K}=${Typefy<O[K]>}`>, N.Add<C, 1>>
     : __$Replace<T, O, S.Replace<TXT, T[C], `${S.Split<T[C], "=">[0]}=${S.Split<T[C], "=">[0]}`>, N.Add<C, 1>>;
 
-export type ReplaceQueryStringValues<T extends string, P extends {}> = __$Replace<S.Split<OnlyQ<T>, "&">, P, T>;
+export type ReplaceQueryStringValues<T extends string, P extends {}> = HasQueryString<T> extends true ? __$Replace<S.Split<OnlyQ<T>, "&">, P, T> : T;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export const mergeUrlEntities = (url: string, params: any | undefined, _qs: any 
     const u = urlEntity(url);
     const path = u.pathname;
     const withParams = replaceUrlParams(path, params);
-    const queryString = qs(_qs);
+    const queryString = _qs === undefined ? "" : qs(_qs);
     const href = queryString === "" ? withParams : `${withParams}?${queryString}`;
     return u.hash ? `${href}#${u.hash}` : href;
 };

--- a/tests/node_modules/.vitest/results.json
+++ b/tests/node_modules/.vitest/results.json
@@ -1,0 +1,1 @@
+{"version":"0.27.1","results":[["/transform-data.test.ts",{"duration":4,"failed":false}],["/utils.test.ts",{"duration":8,"failed":false}]]}

--- a/tests/typings.tsx
+++ b/tests/typings.tsx
@@ -22,6 +22,11 @@ const router = createRouter([
         path: "/users/:id/orders?sort=string!",
         id: "userOrders",
     },
+    {
+        element: <Fragment />,
+        path: "/search?q=string&type=string&arr=string[]",
+        id: "q",
+    },
 ]);
 
 const equals = <A extends any, B extends A>(a: A, b: B): a is B => a === b;
@@ -31,7 +36,9 @@ const shouldTestExpectedLinks = equals(router.links, {
     users: "/users",
     user: "/users/:id",
     userOrders: "/users/:id/orders?sort=string!",
+    q: "/search?q=string&type=string&arr=string[]",
 });
+
 const ShouldTestUserOrdersTypeOutput = equals(router.link(router.links.userOrders, { id: "1" }, { sort: "asc" }), "/users/1/orders?sort=asc");
 const ShouldTestUsers = equals(router.link(router.links.user, { id: "1" }), "/users/1");
 const ShouldTestOneParameter = equals(router.link(router.links.root), "/");

--- a/tests/typings.tsx
+++ b/tests/typings.tsx
@@ -1,0 +1,48 @@
+import { createRouter } from "../src";
+import { Fragment } from "react";
+
+const router = createRouter([
+    {
+        element: <Fragment />,
+        path: "/",
+        id: "root",
+    },
+    {
+        element: <Fragment />,
+        path: "/users",
+        id: "users",
+    },
+    {
+        element: <Fragment />,
+        path: "/users/:id",
+        id: "user",
+    },
+    {
+        element: <Fragment />,
+        path: "/users/:id/orders?sort=string!",
+        id: "userOrders",
+    },
+]);
+
+const equals = <A extends any, B extends A>(a: A, b: B): a is B => a === b;
+
+const shouldTestExpectedLinks = equals(router.links, {
+    root: "/",
+    users: "/users",
+    user: "/users/:id",
+    userOrders: "/users/:id/orders?sort=string!",
+});
+const ShouldTestUserOrdersTypeOutput = equals(router.link(router.links.userOrders, { id: "1" }, { sort: "asc" }), "/users/1/orders?sort=asc");
+const ShouldTestUsers = equals(router.link(router.links.user, { id: "1" }), "/users/1");
+const ShouldTestOneParameter = equals(router.link(router.links.root), "/");
+
+// @ts-expect-error
+const ShouldExpectError = equals(router.link(router.links.root), "/error");
+
+// @ts-expect-error
+const ShouldExpectError = equals(router.link(router.links.user, { id: "1" }), "/user/2");
+
+// @ts-expect-error
+const shouldTestPartialLinks = equals(router.links, {
+    root: "/",
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,15 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "emitDeclarationOnly": true,
-    "declarationDir": "./dist"
+    "declarationDir": "./dist",
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "alwaysStrict": true,
+    "noImplicitAny": true,
+    "allowUnreachableCode": false,
+    "downlevelIteration": false
   },
   "include": [
     "src"

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,6 +5,7 @@
     "tests"
   ],
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "emitDeclarationOnly": false
   }
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "src",
+    "tests"
+  ],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,7 @@
-import { resolve } from "path";
 import { defineConfig } from "vite";
-import dtsPlugin from "vite-plugin-dts";
 
 export default defineConfig({
-    plugins: [dtsPlugin()],
+    plugins: [],
     build: {
         emptyOutDir: false,
         sourcemap: true,


### PR DESCRIPTION
# Features
- Fully typed URL
- Control params of `brouther.link` based on URL

# Description

## Fully typed URL
Now you can provide params and query string to your URL and brouther will convert the params to a fully typed URL. Example: 

```typescript
const url = brouther.link("/users/:id?sort=string", {id:22}, {sort:"asc"})
url === "/users/22?sort=asc" // type and value has this result
```

## brouther.link

Now you can pass 1, 2, or 3 params based on your route.

1. If your route doesn't have query-string or URL params, you can pass only 1 argument (the path)
2. If your route has URL params and doesn't have a query string, you can pass 2 arguments (the path and the dynamic value paths)
3. If you have a query string and don't have URL params, you can pass 2 arguments (the path and the query string)
4. If you have query string and URL params, you must pass 3 arguments (the path, the dynamic value paths and the query string)

# ToDo
- [x] Test all types as unit test