### PR TITLE
feat: filter configuredRoutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The brother router to help in React apps
 ![Downloads](https://img.shields.io/npm/dm/brouther?style=flat-square)
 
 - Strongly typed ecosystem (based in your routes)
-- Simple API (using by `history`)
+- Simple API (abstract [history](https://github.com/remix-run/history) API)
 - Easy configure NotFound route
 - Utility hooks and functions to work with URLs
 - Hook to get your current route and decide where you can render it

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -5,10 +5,18 @@ import "./index.css";
 import { Brouther } from "../../src";
 import { router } from "./routes";
 
+type A = typeof router.config;
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
         <React.Suspense fallback={<div>Loading...</div>}>
-            <Brouther config={router.config}>
+            <Brouther<A>
+                config={router.config}
+                filter={(route, c) => {
+                    const r = route.data;
+                    return true;
+                }}
+            >
                 <App />
             </Brouther>
         </React.Suspense>

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -11,7 +11,7 @@ ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
             <Brouther
                 config={router.config}
                 filter={(route, c) => {
-                    const r = route.data;
+                    console.log(route.data);
                     return true;
                 }}
             >

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
-import { Brouther, } from "../../src";
+import { Brouther } from "../../src";
 import { router } from "./routes";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/playground/src/main.tsx
+++ b/playground/src/main.tsx
@@ -5,12 +5,10 @@ import "./index.css";
 import { Brouther } from "../../src";
 import { router } from "./routes";
 
-type A = typeof router.config;
-
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
     <React.StrictMode>
         <React.Suspense fallback={<div>Loading...</div>}>
-            <Brouther<A>
+            <Brouther
                 config={router.config}
                 filter={(route, c) => {
                     const r = route.data;

--- a/playground/src/routes.tsx
+++ b/playground/src/routes.tsx
@@ -27,14 +27,3 @@ export const router = createMappedRouter({
         element: <Fragment />,
     },
 } as const);
-
-export const linkToPosts = router.link(router.links.double, { status: "ok", id: "9999" }, { language: 5 });
-
-export const routerArray = createRouter([
-    { path: "/users", id: "users", element: <Fragment /> },
-    { path: "/post/:id", id: "post", element: <Fragment /> },
-    { path: "/blog/:tenant?posts=string!", id: "blog", element: <Fragment /> },
-    { path: "/", id: "root", element: <Fragment /> },
-]);
-
-const a = routerArray.link(routerArray.links.blog, { tenant: "cool" }, { posts: "asc" });

--- a/playground/src/routes.tsx
+++ b/playground/src/routes.tsx
@@ -1,29 +1,39 @@
-import { createMappedRouter, createRouter } from "../../src";
+import { createMappedRouter } from "../../src";
 import Root from "./pages/root";
 import UserIdAddress from "./pages/user-id-address";
 import { Fragment, lazy } from "react";
 
 const Users = lazy(() => import("./pages/users"));
 
+const generateData = () => ({ number: Math.random() });
+
 export const router = createMappedRouter({
     index: {
         path: "/",
         element: <Root />,
+        data: generateData(),
     },
     addressList: {
         path: "/user/:id/address/?sort=string",
         element: <UserIdAddress />,
+        data: generateData(),
     },
     users: {
         path: "/users?id=number&date=date[]!",
         element: <Users />,
+        data: generateData(),
     },
     post: {
         path: "/posts/:id?language=number!",
         element: <Users />,
+        data: generateData(),
     },
     double: {
         path: "/posts/:id/status/:status?language=number!",
         element: <Fragment />,
+        data: generateData(),
     },
 } as const);
+
+
+const d = router.config.routes

--- a/playground/src/routes.tsx
+++ b/playground/src/routes.tsx
@@ -34,6 +34,3 @@ export const router = createMappedRouter({
         data: generateData(),
     },
 } as const);
-
-
-const d = router.config.routes

--- a/src/brouther.tsx
+++ b/src/brouther.tsx
@@ -4,6 +4,7 @@ import { BroutherError, NotFoundRoute } from "./errors";
 import { createHref, mapUrlToQueryStringRecord, transformData, urlEntity } from "./utils";
 import { RouterNavigator } from "./router-navigator";
 import { fromStringToValue } from "./mappers";
+import {Function} from "ts-toolbelt";
 
 export type ContextProps = {
     page: Nullable<ConfiguredRoute>;
@@ -25,20 +26,20 @@ type Base = {
     navigation: RouterNavigator;
 };
 
-export type BroutherProps<T extends Base> = React.PropsWithChildren<{
-    config: Base;
+export type BroutherProps<T extends Function.Narrow<Base>> = React.PropsWithChildren<{
+    config: T;
     filter?: (route: T["routes"][number], config: T) => boolean;
 }>;
 
 /*
     Brouther context to configure all routing ecosystem
  */
-export const Brouther = <T extends Base>({ config, children, filter }: BroutherProps<T>) => {
+export const Brouther = <T extends Function.Narrow<Base>>({ config, children, filter }: BroutherProps<T>) => {
     const [location, setLocation] = useState(() => config.history.location);
     const pathName = location.pathname;
     const matches = useMemo(() => {
         const r = filter ? config.routes.filter((route) => filter(route, config as any)) : config.routes;
-        const page = findRoute(pathName, r);
+        const page = findRoute(pathName, r as any);
         const existPage = page !== null;
         return existPage
             ? { page, error: null, params: page.regex.exec(pathName)?.groups ?? {} }

--- a/src/brouther.tsx
+++ b/src/brouther.tsx
@@ -4,7 +4,7 @@ import { BroutherError, NotFoundRoute } from "./errors";
 import { createHref, mapUrlToQueryStringRecord, transformData, urlEntity } from "./utils";
 import { RouterNavigator } from "./router-navigator";
 import { fromStringToValue } from "./mappers";
-import {Function} from "ts-toolbelt";
+import { Function } from "ts-toolbelt";
 
 export type ContextProps = {
     page: Nullable<ConfiguredRoute>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,8 @@
-import { createRouter } from "./router";
-
-export { createRouter, createMappedRouter } from "./router";
+export { createRouter, createMappedRouter, createMappedRouter as createRouterMap, createMappedRouter as createRecordRouter } from "./router";
 export { Brouther, useUrlSearchParams, usePage, useNavigation, useErrorPage, usePaths, useQueryString, useHref } from "./brouther";
 export { BroutherError, NotFoundRoute } from "./errors";
 export { Link } from "./link";
 export type { LinkProps } from "./link";
 export type { RouterNavigator } from "./router-navigator";
 export { urlEntity, mergeUrlEntities, createHref, qsToString, transformData } from "./utils";
-export type {
-    UrlParams,
-    QueryStringMappers,
-    Pathname,
-    PathsMap,
-    QueryStringExists,
-    ConfiguredRoute,
-    QueryString,
-    Route,
-} from "./types";
+export type { UrlParams, QueryStringMappers, Pathname, PathsMap, QueryStringExists, ConfiguredRoute, QueryString, Route } from "./types";

--- a/src/router.ts
+++ b/src/router.ts
@@ -56,14 +56,8 @@ export const createRouter = <T extends readonly Route[], Basename extends string
         link: createLink(routes as Route[]) as any,
         usePaths: createUsePaths(routes as Route[]) as any,
         useQueryString: createUseQueryString(routes as Route[]) as any,
-        config: { routes: configureRoutes(routes as Route[]), history, navigation, basename } as any,
-        links: (routes as Route[]).reduce(
-            (acc, el) => ({
-                ...acc,
-                [el.id]: el.path,
-            }),
-            {}
-        ) as any,
+        config: { routes: configureRoutes(routes as any), history, navigation, basename } as any,
+        links: (routes as Route[]).reduce((acc, el) => ({ ...acc, [el.id]: el.path }), {}) as any,
     };
 };
 
@@ -72,6 +66,9 @@ export const createMappedRouter = <T extends Function.Narrow<Router>, Basename e
     basename: Basename = "/" as any
 ): CreateMappedRoute<T> =>
     createRouter(
-        Object.keys(routes).map((x) => ({ ...routes[x], id: x })),
+        Object.keys(routes).map((id) => {
+            const o = routes[id];
+            return { id, path: o.path, data: o.data, element: o.element };
+        }),
         basename
     ) as any;

--- a/src/router.ts
+++ b/src/router.ts
@@ -39,6 +39,7 @@ const configureRoutes = (arr: Route[]): ConfiguredRoute[] =>
                 path,
                 regex,
                 id: x.id,
+                data: x.data,
                 element: x.element,
                 originalPath: x.path,
             };

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,15 +10,16 @@ export type Hide<T, K extends keyof T> = Omit<T, K>;
 
 export type QueryStringPrimitive = string | number | null | boolean | Date | QueryStringPrimitive[];
 
-export type ConfiguredRoute = Route & { regex: RegExp; originalPath: string };
-
 export type Router = Record<string, Hide<Route, "id">>;
 
-export type Route = {
+export type Route<Data extends {} | undefined = {}> = {
     id: Readonly<string>;
     path: Readonly<string>;
     element: React.ReactElement;
+    data?: Data;
 };
+
+export type ConfiguredRoute<Data extends {} | undefined = {}> = Route<Data> & { regex: RegExp; originalPath: string };
 
 export type QueryStringMappers = {
     string: string;
@@ -63,7 +64,9 @@ export type RemapQueryString<Queries extends readonly string[], I extends number
 
 export type HasQueryString<Path extends string> = OnlyQ<Path> extends "" ? false : true;
 
-export type QueryString<Query extends string> = HasQueryString<Query> extends true ? Union.Merge<RemapQueryString<String.Split<OnlyQ<Query>, "&">>> : {};
+export type QueryString<Query extends string> = HasQueryString<Query> extends true
+    ? Union.Merge<RemapQueryString<String.Split<OnlyQ<Query>, "&">>>
+    : {};
 
 export type QueryStringRecord = Record<string, QueryStringPrimitive>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,7 @@ export type RemapQueryString<Queries extends readonly string[], I extends number
 
 export type HasQueryString<Path extends string> = OnlyQ<Path> extends "" ? false : true;
 
-export type QueryString<Query extends string> = HasQueryString<Query> extends true ? RemapQueryString<String.Split<OnlyQ<Query>, "&">> : {};
+export type QueryString<Query extends string> = HasQueryString<Query> extends true ? Union.Merge<RemapQueryString<String.Split<OnlyQ<Query>, "&">>> : {};
 
 export type QueryStringRecord = Record<string, QueryStringPrimitive>;
 
@@ -181,3 +181,11 @@ export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = CommonR
 };
 
 type BrowserHistory = ReturnType<typeof createBrowserHistory>;
+
+export type CustomSearchParams<T extends {} = {}> = Hide<URLSearchParams, "get" | "getAll" | "append" | "set" | "delete"> & {
+    readonly get: <K extends keyof T>(name: K) => string | null;
+    readonly getAll: <K extends keyof T>(name: K) => string[];
+    readonly append: <K extends keyof T>(name: K, value: string) => void;
+    readonly set: <K extends keyof T>(name: K, value: string) => void;
+    readonly delete: <K extends keyof T>(name: K) => void;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import type React from "react";
-import type {Function, Number, Object, String, Union} from "ts-toolbelt";
-import type {RouterNavigator} from "./router-navigator";
-import type {QueryStringMapper} from "./mappers";
-import type {createBrowserHistory} from "history";
+import type { Function, Number, Object, String, Union } from "ts-toolbelt";
+import type { RouterNavigator } from "./router-navigator";
+import type { QueryStringMapper } from "./mappers";
+import type { createBrowserHistory } from "history";
 
 export type Nullable<T> = T | null;
 
@@ -36,10 +36,10 @@ export type FetchPaths<Routes extends Function.Narrow<Route[]>> = NonNullable<{ 
 export type UrlParams<T extends string> = string extends T
     ? Record<string, string>
     : T extends `${infer _}:${infer Param}/${infer Rest}`
-        ? { [k in Param | keyof UrlParams<Rest>]: string }
-        : T extends `${infer _}:${infer Param}`
-            ? { [k in Param]: string }
-            : null;
+    ? { [k in Param | keyof UrlParams<Rest>]: string }
+    : T extends `${infer _}:${infer Param}`
+    ? { [k in Param]: string }
+    : null;
 
 export type QueryStringExists<Path extends Function.Narrow<string>> = Path extends `${string}?${string}` ? true : false;
 
@@ -48,21 +48,21 @@ export type AsArray<Type extends string> = Type extends `${infer R}[]` ? R : Typ
 export type Mapper<Type extends string> = Type extends keyof QueryStringMappers
     ? QueryStringMappers[Type]
     : Type extends `${keyof QueryStringMappers}[]`
-        ? QueryStringMappers[AsArray<Type>][]
-        : Type;
+    ? QueryStringMappers[AsArray<Type>][]
+    : Type;
 
 export type OnlyQ<Path extends string> = Path extends `${infer _}?${infer I}` ? I : never;
 
 export type RemapQueryString<Queries extends readonly string[], I extends number = 0> = I extends Queries["length"]
     ? {}
     : (String.Split<Queries[I], "=">[1] extends `${infer Value}!`
-    ? {
-        [K in String.Split<Queries[I], "=">[0]]: Mapper<Value>;
-    }
-    : {
-        [K in String.Split<Queries[I], "=">[0]]: Mapper<String.Split<Queries[I], "=">[1]>;
-    }) &
-    RemapQueryString<Queries, Number.Add<I, 1>>;
+          ? {
+                [K in String.Split<Queries[I], "=">[0]]: Mapper<Value>;
+            }
+          : {
+                [K in String.Split<Queries[I], "=">[0]]: Mapper<String.Split<Queries[I], "=">[1]>;
+            }) &
+          RemapQueryString<Queries, Number.Add<I, 1>>;
 
 export type HasQueryString<Path extends string> = OnlyQ<Path> extends "" ? false : true;
 
@@ -95,8 +95,8 @@ export type CreateHref<T extends Function.Narrow<Route[]>> = <
             ? [path: Path, qs: QS, parsers?: QueryStringParsers]
             : [path: Path]
         : HasQueryString<Path> extends true
-            ? [path: Path, params: Params, qs: QS, parsers?: QueryStringParsers]
-            : [path: Path, params: Params]
+        ? [path: Path, params: Params, qs: QS, parsers?: QueryStringParsers]
+        : [path: Path, params: Params]
 ) => Params extends null
     ? ReplaceQueryString<Path, Function.Narrow<NonNullable<QS>>>
     : ReplaceQueryString<ReplaceParams<Path, NonNullable<Params>>, Function.Narrow<NonNullable<QS>>>;
@@ -120,12 +120,12 @@ type BuildQueryStringParam<Key extends string, Value extends any[], C extends nu
 type ExtractQueryStringValue<K extends string, Value> = Value extends any[]
     ? BuildQueryStringParam<K, Value>
     : Value extends Date
-        ? [`${K}=${string}`]
-        : Value extends string | number
-            ? [`${K}=${Value}`]
-            : Value extends undefined | null
-                ? [`${K}=`]
-                : [`${K}=`];
+    ? [`${K}=${string}`]
+    : Value extends string | number
+    ? [`${K}=${Value}`]
+    : Value extends undefined | null
+    ? [`${K}=`]
+    : [`${K}=`];
 
 type ReplaceQSValues<
     Path extends string,
@@ -138,8 +138,8 @@ type ReplaceQSValues<
         ? Path
         : `${String.Split<Path, "?">[0]}?${String.Join<Result, "&">}`
     : Queries[C] extends `${infer K}=${infer R}`
-        ? ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, ...ExtractQueryStringValue<K, Values[K]>]>
-        : ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, `${string}=${string}`]>;
+    ? ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, ...ExtractQueryStringValue<K, Values[K]>]>
+    : ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, `${string}=${string}`]>;
 
 export type ReplaceQueryString<Path extends string, Query extends {}> = HasQueryString<Path> extends true
     ? ReplaceQSValues<String.Split<Path, "?">[0], String.Split<OnlyQ<Path>, "&">, Query>
@@ -159,18 +159,16 @@ type RouteConfig<Data extends RouteData = {}> = {
 export type AsRouter<T extends readonly Route[], C extends number = 0, Acc extends Router = {}> = C extends T["length"]
     ? Acc
     : AsRouter<
-        T,
-        Number.Add<C, 1>,
-        Acc & {
-        [K in T[C]["id"]]: T[C];
-    }
-    >;
+          T,
+          Number.Add<C, 1>,
+          Acc & {
+              [K in T[C]["id"]]: T[C];
+          }
+      >;
 
 export type BrowserHistory = ReturnType<typeof createBrowserHistory>;
 
-export type CustomSearchParams<T extends {} = {}> =
-    Hide<URLSearchParams, "get" | "getAll" | "append" | "set" | "delete">
-    & {
+export type CustomSearchParams<T extends {} = {}> = Hide<URLSearchParams, "get" | "getAll" | "append" | "set" | "delete"> & {
     readonly get: <K extends keyof T>(name: K) => string | null;
     readonly getAll: <K extends keyof T>(name: K) => string[];
     readonly append: <K extends keyof T>(name: K, value: string) => void;
@@ -187,7 +185,7 @@ export type ConfiguredRoutesAcc<T extends Function.Narrow<Router>> = ReduceConfi
 export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = {
     navigation: RouterNavigator;
     links: { [Key in keyof _Router]: _Router[Key]["path"] };
-    config: Function.Narrow<{ routes: ConfiguredRoutesAcc<_Router> } & Hide<RouteConfig, "routes">>
+    config: Function.Narrow<{ routes: ConfiguredRoutesAcc<_Router> } & Hide<RouteConfig, "routes">>;
     usePaths: <Path extends PathsMap<_Router>>(path: Path) => UrlParams<Pathname<Path>> extends null ? {} : UrlParams<Pathname<Path>>;
     useQueryString: <Path extends PathsMap<_Router>>(path: Path) => QueryString<Path>;
     link: <
@@ -200,8 +198,8 @@ export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = {
                 ? readonly [path: Path, qs: Readonly<QS>]
                 : readonly [path: Path]
             : HasQueryString<Path> extends true
-                ? readonly [path: Path, params: Readonly<Params>, qs: Readonly<QS>]
-                : readonly [path: Path, params: Readonly<Params>]
+            ? readonly [path: Path, params: Readonly<Params>, qs: Readonly<QS>]
+            : readonly [path: Path, params: Readonly<Params>]
     ) => Params extends null
         ? ReplaceQueryString<Path, NonNullable<QS>>
         : ReplaceQueryString<ReplaceParams<Path, NonNullable<Params>>, NonNullable<QS>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,8 @@
 import type React from "react";
-import type { Function, Number, Object, String, Union } from "ts-toolbelt";
-import type { RouterNavigator } from "./router-navigator";
-import type { QueryStringMapper } from "./mappers";
-import type { createBrowserHistory } from "history";
+import type {Function, Number, Object, String, Union} from "ts-toolbelt";
+import type {RouterNavigator} from "./router-navigator";
+import type {QueryStringMapper} from "./mappers";
+import type {createBrowserHistory} from "history";
 
 export type Nullable<T> = T | null;
 
@@ -36,10 +36,10 @@ export type FetchPaths<Routes extends Function.Narrow<Route[]>> = NonNullable<{ 
 export type UrlParams<T extends string> = string extends T
     ? Record<string, string>
     : T extends `${infer _}:${infer Param}/${infer Rest}`
-    ? { [k in Param | keyof UrlParams<Rest>]: string }
-    : T extends `${infer _}:${infer Param}`
-    ? { [k in Param]: string }
-    : null;
+        ? { [k in Param | keyof UrlParams<Rest>]: string }
+        : T extends `${infer _}:${infer Param}`
+            ? { [k in Param]: string }
+            : null;
 
 export type QueryStringExists<Path extends Function.Narrow<string>> = Path extends `${string}?${string}` ? true : false;
 
@@ -48,21 +48,21 @@ export type AsArray<Type extends string> = Type extends `${infer R}[]` ? R : Typ
 export type Mapper<Type extends string> = Type extends keyof QueryStringMappers
     ? QueryStringMappers[Type]
     : Type extends `${keyof QueryStringMappers}[]`
-    ? QueryStringMappers[AsArray<Type>][]
-    : Type;
+        ? QueryStringMappers[AsArray<Type>][]
+        : Type;
 
 export type OnlyQ<Path extends string> = Path extends `${infer _}?${infer I}` ? I : never;
 
 export type RemapQueryString<Queries extends readonly string[], I extends number = 0> = I extends Queries["length"]
     ? {}
     : (String.Split<Queries[I], "=">[1] extends `${infer Value}!`
-          ? {
-                [K in String.Split<Queries[I], "=">[0]]: Mapper<Value>;
-            }
-          : {
-                [K in String.Split<Queries[I], "=">[0]]: Mapper<String.Split<Queries[I], "=">[1]>;
-            }) &
-          RemapQueryString<Queries, Number.Add<I, 1>>;
+    ? {
+        [K in String.Split<Queries[I], "=">[0]]: Mapper<Value>;
+    }
+    : {
+        [K in String.Split<Queries[I], "=">[0]]: Mapper<String.Split<Queries[I], "=">[1]>;
+    }) &
+    RemapQueryString<Queries, Number.Add<I, 1>>;
 
 export type HasQueryString<Path extends string> = OnlyQ<Path> extends "" ? false : true;
 
@@ -95,8 +95,8 @@ export type CreateHref<T extends Function.Narrow<Route[]>> = <
             ? [path: Path, qs: QS, parsers?: QueryStringParsers]
             : [path: Path]
         : HasQueryString<Path> extends true
-        ? [path: Path, params: Params, qs: QS, parsers?: QueryStringParsers]
-        : [path: Path, params: Params]
+            ? [path: Path, params: Params, qs: QS, parsers?: QueryStringParsers]
+            : [path: Path, params: Params]
 ) => Params extends null
     ? ReplaceQueryString<Path, Function.Narrow<NonNullable<QS>>>
     : ReplaceQueryString<ReplaceParams<Path, NonNullable<Params>>, Function.Narrow<NonNullable<QS>>>;
@@ -120,12 +120,12 @@ type BuildQueryStringParam<Key extends string, Value extends any[], C extends nu
 type ExtractQueryStringValue<K extends string, Value> = Value extends any[]
     ? BuildQueryStringParam<K, Value>
     : Value extends Date
-    ? [`${K}=${string}`]
-    : Value extends string | number
-    ? [`${K}=${Value}`]
-    : Value extends undefined | null
-    ? [`${K}=`]
-    : [`${K}=`];
+        ? [`${K}=${string}`]
+        : Value extends string | number
+            ? [`${K}=${Value}`]
+            : Value extends undefined | null
+                ? [`${K}=`]
+                : [`${K}=`];
 
 type ReplaceQSValues<
     Path extends string,
@@ -138,8 +138,8 @@ type ReplaceQSValues<
         ? Path
         : `${String.Split<Path, "?">[0]}?${String.Join<Result, "&">}`
     : Queries[C] extends `${infer K}=${infer R}`
-    ? ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, ...ExtractQueryStringValue<K, Values[K]>]>
-    : ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, `${string}=${string}`]>;
+        ? ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, ...ExtractQueryStringValue<K, Values[K]>]>
+        : ReplaceQSValues<Path, Queries, Values, Number.Add<C, 1>, [...Result, `${string}=${string}`]>;
 
 export type ReplaceQueryString<Path extends string, Query extends {}> = HasQueryString<Path> extends true
     ? ReplaceQSValues<String.Split<Path, "?">[0], String.Split<OnlyQ<Path>, "&">, Query>
@@ -159,16 +159,18 @@ type RouteConfig<Data extends RouteData = {}> = {
 export type AsRouter<T extends readonly Route[], C extends number = 0, Acc extends Router = {}> = C extends T["length"]
     ? Acc
     : AsRouter<
-          T,
-          Number.Add<C, 1>,
-          Acc & {
-              [K in T[C]["id"]]: T[C];
-          }
-      >;
+        T,
+        Number.Add<C, 1>,
+        Acc & {
+        [K in T[C]["id"]]: T[C];
+    }
+    >;
 
 export type BrowserHistory = ReturnType<typeof createBrowserHistory>;
 
-export type CustomSearchParams<T extends {} = {}> = Hide<URLSearchParams, "get" | "getAll" | "append" | "set" | "delete"> & {
+export type CustomSearchParams<T extends {} = {}> =
+    Hide<URLSearchParams, "get" | "getAll" | "append" | "set" | "delete">
+    & {
     readonly get: <K extends keyof T>(name: K) => string | null;
     readonly getAll: <K extends keyof T>(name: K) => string[];
     readonly append: <K extends keyof T>(name: K, value: string) => void;
@@ -184,8 +186,8 @@ export type ConfiguredRoutesAcc<T extends Function.Narrow<Router>> = ReduceConfi
 
 export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = {
     navigation: RouterNavigator;
-    config: { routes: ConfiguredRoutesAcc<_Router> } & Hide<RouteConfig, "routes">;
     links: { [Key in keyof _Router]: _Router[Key]["path"] };
+    config: Function.Narrow<{ routes: ConfiguredRoutesAcc<_Router> } & Hide<RouteConfig, "routes">>
     usePaths: <Path extends PathsMap<_Router>>(path: Path) => UrlParams<Pathname<Path>> extends null ? {} : UrlParams<Pathname<Path>>;
     useQueryString: <Path extends PathsMap<_Router>>(path: Path) => QueryString<Path>;
     link: <
@@ -198,8 +200,8 @@ export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = {
                 ? readonly [path: Path, qs: Readonly<QS>]
                 : readonly [path: Path]
             : HasQueryString<Path> extends true
-            ? readonly [path: Path, params: Readonly<Params>, qs: Readonly<QS>]
-            : readonly [path: Path, params: Readonly<Params>]
+                ? readonly [path: Path, params: Readonly<Params>, qs: Readonly<QS>]
+                : readonly [path: Path, params: Readonly<Params>]
     ) => Params extends null
         ? ReplaceQueryString<Path, NonNullable<QS>>
         : ReplaceQueryString<ReplaceParams<Path, NonNullable<Params>>, NonNullable<QS>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,23 +10,25 @@ export type Hide<T, K extends keyof T> = Omit<T, K>;
 
 export type QueryStringPrimitive = string | number | null | boolean | Date | QueryStringPrimitive[];
 
-export type Router = Record<string, Hide<Route, "id">>;
+type RouteData = Record<string, string> | undefined;
 
-export type Route<Data extends {} | undefined = {}> = {
+export type Router<Data extends RouteData = {}> = Record<string, Hide<Route, "id">>;
+
+export type Route<Data extends RouteData = {}> = {
     id: Readonly<string>;
     path: Readonly<string>;
     element: React.ReactElement;
     data?: Data;
 };
 
-export type ConfiguredRoute<Data extends {} | undefined = {}> = Route<Data> & { regex: RegExp; originalPath: string };
+export type ConfiguredRoute<Data extends RouteData = {}> = Route<Data> & { regex: RegExp; originalPath: string };
 
 export type QueryStringMappers = {
+    date: Date;
+    null: null;
     string: string;
     number: number;
     boolean: boolean;
-    date: Date;
-    null: null;
 };
 
 export type FetchPaths<Routes extends Function.Narrow<Route[]>> = NonNullable<{ [_ in keyof Routes[number]]: Routes[number]["path"] }["path"]>;
@@ -147,9 +149,11 @@ export type Parser = (data: any, key: string) => any;
 
 export type ParsersMap = Map<string, Parser>;
 
-export type CommonRoute = {
+type RouteConfig<Data extends RouteData = {}> = {
+    routes: ConfiguredRoute<Data>[];
     navigation: RouterNavigator;
-    config: { routes: ConfiguredRoute[]; navigation: RouterNavigator; basename: string; history: BrowserHistory };
+    basename: string;
+    history: BrowserHistory;
 };
 
 export type AsRouter<T extends readonly Route[], C extends number = 0, Acc extends Router = {}> = C extends T["length"]
@@ -162,7 +166,25 @@ export type AsRouter<T extends readonly Route[], C extends number = 0, Acc exten
           }
       >;
 
-export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = CommonRoute & {
+export type BrowserHistory = ReturnType<typeof createBrowserHistory>;
+
+export type CustomSearchParams<T extends {} = {}> = Hide<URLSearchParams, "get" | "getAll" | "append" | "set" | "delete"> & {
+    readonly get: <K extends keyof T>(name: K) => string | null;
+    readonly getAll: <K extends keyof T>(name: K) => string[];
+    readonly append: <K extends keyof T>(name: K, value: string) => void;
+    readonly set: <K extends keyof T>(name: K, value: string) => void;
+    readonly delete: <K extends keyof T>(name: K) => void;
+};
+
+type ReduceConfiguredRoutes<T extends readonly any[], Acc extends readonly Route[] = [], C extends number = 0> = C extends T["length"]
+    ? Acc
+    : ReduceConfiguredRoutes<T, [...Acc, { regex: RegExp; originalPath: string; id: string } & T[C]], Number.Add<C, 1>>;
+
+export type ConfiguredRoutesAcc<T extends Function.Narrow<Router>> = ReduceConfiguredRoutes<Union.ListOf<Object.UnionOf<T>>>;
+
+export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = {
+    navigation: RouterNavigator;
+    config: { routes: ConfiguredRoutesAcc<_Router> } & Hide<RouteConfig, "routes">;
     links: { [Key in keyof _Router]: _Router[Key]["path"] };
     usePaths: <Path extends PathsMap<_Router>>(path: Path) => UrlParams<Pathname<Path>> extends null ? {} : UrlParams<Pathname<Path>>;
     useQueryString: <Path extends PathsMap<_Router>>(path: Path) => QueryString<Path>;
@@ -181,14 +203,4 @@ export type CreateMappedRoute<_Router extends Function.Narrow<Router>> = CommonR
     ) => Params extends null
         ? ReplaceQueryString<Path, NonNullable<QS>>
         : ReplaceQueryString<ReplaceParams<Path, NonNullable<Params>>, NonNullable<QS>>;
-};
-
-type BrowserHistory = ReturnType<typeof createBrowserHistory>;
-
-export type CustomSearchParams<T extends {} = {}> = Hide<URLSearchParams, "get" | "getAll" | "append" | "set" | "delete"> & {
-    readonly get: <K extends keyof T>(name: K) => string | null;
-    readonly getAll: <K extends keyof T>(name: K) => string[];
-    readonly append: <K extends keyof T>(name: K, value: string) => void;
-    readonly set: <K extends keyof T>(name: K, value: string) => void;
-    readonly delete: <K extends keyof T>(name: K) => void;
 };

--- a/tests/node_modules/.vitest/results.json
+++ b/tests/node_modules/.vitest/results.json
@@ -1,1 +1,1 @@
-{"version":"0.28.4","results":[["/links.test.ts",{"duration":8,"failed":false}],["/qs.test.ts",{"duration":7,"failed":false}],["/utils.test.ts",{"duration":15,"failed":false}],["/transform-data.test.ts",{"duration":6,"failed":false}]]}
+{"version":"0.28.4","results":[["/links.test.ts",{"duration":5,"failed":false}],["/qs.test.ts",{"duration":4,"failed":false}],["/utils.test.ts",{"duration":12,"failed":false}],["/transform-data.test.ts",{"duration":7,"failed":false}]]}

--- a/tests/node_modules/.vitest/results.json
+++ b/tests/node_modules/.vitest/results.json
@@ -1,0 +1,1 @@
+{"version":"0.28.4","results":[["/links.test.ts",{"duration":8,"failed":false}],["/qs.test.ts",{"duration":7,"failed":false}],["/utils.test.ts",{"duration":15,"failed":false}],["/transform-data.test.ts",{"duration":6,"failed":false}]]}

--- a/tests/typings.tsx
+++ b/tests/typings.tsx
@@ -1,5 +1,7 @@
-import { createRouter } from "../src";
+import { createRouter, usePaths, useQueryString, useUrlSearchParams } from "../src";
 import { Fragment } from "react";
+
+const equals = <A extends any, B extends A>(a: A, b: B): a is B => a === b;
 
 const router = createRouter([
     {
@@ -29,8 +31,6 @@ const router = createRouter([
     },
 ]);
 
-const equals = <A extends any, B extends A>(a: A, b: B): a is B => a === b;
-
 const shouldTestExpectedLinks = equals(router.links, {
     root: "/",
     users: "/users",
@@ -53,3 +53,19 @@ const ShouldExpectError = equals(router.link(router.links.user, { id: "1" }), "/
 const shouldTestPartialLinks = equals(router.links, {
     root: "/",
 });
+
+const urlSearchParams = useUrlSearchParams<{ key: string; value: string }>();
+// @ts-expect-error
+urlSearchParams.get("key-not-exist");
+
+const qs = useQueryString(router.links.q);
+qs.q;
+qs.type;
+qs.arr;
+// @ts-expect-error
+qs.error;
+
+const paths = usePaths(router.links.user);
+paths.id;
+// @ts-expect-error
+paths.adsas;


### PR DESCRIPTION
# Motivation

If you have [Feature Flags](https://martinfowler.com/articles/feature-toggles.html) or you just need to remove some pages from your website, you will need a way to filter. This PR introduce this feature. 

Now you can filter the configuredRoutes (used by brouther to create internal config) using the attribute `filter` in `<Brouther />` component.

# Features

1. Control your routes without memo/extra code to avoid rerender
2. Your routes can have `data`, a custom object with your own rules

# Other features

- [ ] Correct README
- [ ] Remove unused code in playground
- [ ] Add types to `useQueryString` and `usePaths` based on generics