### PR TITLE
feat: Rank Routes

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,3 +100,14 @@ export const createLink =
     <T extends Function.Narrow<Route[]>>(_routes: T): CreateHref<T> =>
     (...args: any): any =>
         mergeUrlEntities(args[0], args[1], args[2], args[3]) as never;
+
+const rankBinds = (path: string) => path.split(":").length * 5;
+
+const rankPaths = (path: string) => path.split("/").length;
+
+export const rankRoutes = <T extends Array<{ path: string }>>(routes: T) =>
+    routes.sort((a, b) => {
+        const scoreA = rankPaths(a.path) + rankBinds(a.path);
+        const scoreB = rankPaths(b.path) + rankBinds(b.path);
+        return scoreA - scoreB;
+    });

--- a/tests/node_modules/.vitest/results.json
+++ b/tests/node_modules/.vitest/results.json
@@ -1,1 +1,1 @@
-{"version":"0.28.4","results":[["/links.test.ts",{"duration":5,"failed":false}],["/qs.test.ts",{"duration":4,"failed":false}],["/utils.test.ts",{"duration":12,"failed":false}],["/transform-data.test.ts",{"duration":7,"failed":false}]]}
+{"version":"0.28.4","results":[["/links.test.ts",{"duration":5,"failed":false}],["/qs.test.ts",{"duration":2,"failed":false}],["/utils.test.ts",{"duration":9,"failed":false}],["/transform-data.test.ts",{"duration":2,"failed":false}],["/rank-routes.test.ts",{"duration":2,"failed":false}]]}

--- a/tests/rank-routes.test.ts
+++ b/tests/rank-routes.test.ts
@@ -1,0 +1,35 @@
+import { rankRoutes } from "../src/utils";
+import { describe, it, expect } from "vitest";
+
+const test = it.concurrent;
+
+describe("Should test rankRoutes", function () {
+    test("Should test rank with no special routes", () => {
+        const result = rankRoutes([{ path: "/" }, { path: "/users" }, { path: "/contact-us" }, { path: "/users/1/address/5" }]);
+        expect(result.length === 4);
+        expect(result[0].path).toBe("/");
+        expect(result[3].path).toBe("/users/1/address/5");
+    });
+
+    test("Should test rank with one special routes", () => {
+        const result = rankRoutes([{ path: "/" }, { path: "/:id" }, { path: "/contact-us" }, { path: "/users/1/address/5" }]);
+        expect(result.length === 4);
+        expect(result[0].path).toBe("/");
+        expect(result[3].path).toBe("/:id");
+    });
+
+    test("Should test rank with all special routes", () => {
+        const result = rankRoutes([
+            { path: "/users/address/:id/:action" },
+            { path: "/contact-us/:type/:id" },
+            { path: "/" },
+            { path: "/contact-us/cellphone/:id" },
+            { path: "/users/address/:id/remove" },
+            { path: "/:id" },
+        ]);
+        expect(result.length === 1);
+        expect(result[0].path).toBe("/");
+        expect(result[4].path).toBe("/contact-us/:type/:id");
+        expect(result[5].path).toBe("/users/address/:id/:action");
+    });
+});


### PR DESCRIPTION
# Description

Use a custom logic to avoid mistakes when you have similar paths, but one uses static paths `/users/new` and the other uses dynamic path `/users/:action` on a deep level.

I would like to explain more. You provide the items below in the same order:

1. `/`
2. `/users/new`
3. `/users/address/:id/remove`
4. `/users/address/new`

Without rank routes, you may have problems with this, because item 3 is very open and embraces the numbers 2 and 4. But using the rank route brouther will understand the correct order when matching the path. 

1. `/`
2. `/users/new`
3. `/users/address/new`
4. `/users/address/:id/remove`