### PR TITLE
fix: at least type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brouther",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "brouther",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "dependencies": {
         "history": "5.3.0",
         "qs": "6.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brouther",
   "type": "module",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -70,9 +70,9 @@ export const createRoute = <
     data?: Data
 ): Route<Path, Data, NonNullable<Args["id"]>> => ({ ...args, id: args.id ?? path, data, path: path as never });
 
-export const createRouter = <const T extends Function.Narrow<readonly Route[]>, const Basename extends string>(
+export const createRouter = <const T extends Function.Narrow<readonly Readonly<Route>[]>, const Basename extends string>(
     routes: Function.Narrow<Readonly<T>>,
-    basename: Basename = "/" as any,
+    basename: Basename = "/" as Basename,
     historyCreate?: () => BrowserHistory
 ): CreateMappedRoute<AsRouter<T>> => {
     const fn = historyCreate ?? createBrowserHistory;
@@ -81,17 +81,11 @@ export const createRouter = <const T extends Function.Narrow<readonly Route[]>, 
     const routesConfig = configureRoutes(routes as any, basename);
     return {
         navigation,
-        link: createLink(routes as Route[]) as any,
+        link: createLink(routes as Route[]),
         usePaths: createUsePaths(routes as Route[]) as any,
         useQueryString: createUseQueryString(routes as Route[]) as any,
         config: { routes: routesConfig, history, navigation, basename } as any,
-        links: (routes as Route[]).reduce(
-            (acc, el) => ({
-                ...acc,
-                [el.id]: el.path,
-            }),
-            {}
-        ) as any,
+        links: (routes as Route[]).reduce((acc, el) => ({ ...acc, [el.id]: el.path }), {}) as any,
     };
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,22 +59,22 @@ export type FetchPaths<Routes extends readonly Route[]> = NonNullable<{ [_ in ke
 
 export type CreateHref<T extends readonly Route[]> = <
     const Path extends FetchPaths<T>,
-    const Qs extends Readonly<Paths.PathsQs<Path>>,
-    const Params extends Paths.Parse<Paths.Pathname<Path>> extends null ? null : Function.Narrow<Readonly<Paths.Parse<Paths.Pathname<Path>>>>,
+    const Qs extends QueryString.Parse<Path>,
+    const Params extends Paths.Parse<Path>,
     const QueryStringParsers extends QueryString.ParseURL<Path>
 >(
-    ...args: Params extends null
+    ...args: Paths.Parse<Path> extends null
         ? QueryString.Has<Path> extends true
-            ? X.AtLeastOne<Qs> extends true
+            ? X.AtLeastOne<QueryString.Parse<Path>> extends true
                 ? readonly [path: Path, qs: Qs, parsers?: QueryStringParsers]
                 : readonly [path: Path, qs?: Qs, parsers?: QueryStringParsers]
             : readonly [path: Path]
         : QueryString.Has<Path> extends true
-        ? X.AtLeastOne<Qs> extends true
+        ? X.AtLeastOne<QueryString.Parse<Path>> extends true
             ? readonly [path: Path, params: Params, qs: Qs, parsers?: QueryStringParsers]
             : readonly [path: Path, params: Params, qs?: Qs, parsers?: QueryStringParsers]
-        : readonly [path: Path, params: Params]
-) => Params extends null
+        : readonly [path: Path, params: Paths.Parse<Path>]
+) => Paths.Parse<Path> extends null
     ? QueryString.Assign<Path, NonNullable<Qs>>
     : QueryString.Assign<Paths.Assign<Path, NonNullable<Params>>, Function.Narrow<NonNullable<Qs>>>;
 

--- a/src/types/x.ts
+++ b/src/types/x.ts
@@ -1,4 +1,4 @@
-import { List, Union, Number } from "ts-toolbelt";
+import type { List, Union, Number, Object } from "ts-toolbelt";
 
 export namespace X {
     export type Nullable<T> = T | null;
@@ -12,10 +12,11 @@ export namespace X {
     export type Promisify<T> = T | Promise<T>;
 
     export type ReduceKeys<T extends {}, Keys extends List.List, C extends number = 0> = Keys["length"] extends C
-        ? false
-        : T[Keys[C]] extends T[Keys[C]] | undefined
-        ? false
+      ? false
+      : T[Keys[C]] extends T[Keys[C]] | undefined
+        ? Object.UnionOf<Keys[C]> extends (undefined|Object.UnionOf<Keys[C]>) ? true : false
         : ReduceKeys<T, Keys, Number.Add<C, 1>>;
 
     export type AtLeastOne<T extends {} | null> = T extends null ? false : ReduceKeys<NonNullable<T>, Union.ListOf<T>>;
+
 }

--- a/tests/typings.tsx
+++ b/tests/typings.tsx
@@ -1,4 +1,4 @@
-import { Actions, createRoute, createRouter, createRouterMap, usePaths, useQueryString, useUrlSearchParams } from "../src";
+import { createRouter, createRouterMap, usePaths, useQueryString, useUrlSearchParams } from "../src";
 import { Fragment } from "react";
 
 const equals = <A extends any, B extends A>(a: A, b: B): a is B => a === b;
@@ -29,7 +29,7 @@ const router = createRouter([
         path: "/search?q=string&type=string&arr=string[]",
         id: "q",
     },
-]);
+] as const);
 
 const shouldTestExpectedLinks = equals(router.links, {
     root: "/",
@@ -39,7 +39,7 @@ const shouldTestExpectedLinks = equals(router.links, {
     q: "/search?q=string&type=string&arr=string[]",
 });
 
-const ShouldTestUserOrdersTypeOutput = equals(router.link(router.links.userOrders, { id: "1" }, { sort: "asc" }), "/users/1/orders?sort=asc");
+const ShouldTestUserOrdersTypeOutput = equals(router.link(router.links.user, { id: "1" }), "/users/1/orders?sort=asc");
 const ShouldTestUsers = equals(router.link(router.links.user, { id: "1" }), "/users/1");
 const ShouldTestOneParameter = equals(router.link(router.links.root), "/");
 const ShouldQEqual = equals(
@@ -90,5 +90,10 @@ const map = createRouterMap({
 });
 
 console.log(map.link(map.links.atLeast, { region: "Brazil" }, { lang: "cool" }));
-const r = map.link(map.links.atLeastOnlyQs, { region: "Brazil" }, { date: new Date() });
+const r = map.link(map.links.atLeast, { region: "Brazil" } as const, {
+    lang: "lang",
+    discount: 1,
+});
 console.log(r);
+
+const atLeast = map.link(map.links.atLeast, { region: "Brasil" }, { lang: "" });


### PR DESCRIPTION
# Description

Now `X.AtLeastType` really require an object if one of the keys doesn't extend `undefined`