### PR TITLE
fix: type to check the required query string parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brouther",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "brouther",
-      "version": "4.3.1",
+      "version": "4.3.2",
       "dependencies": {
         "history": "5.3.0",
         "qs": "6.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "brouther",
   "type": "module",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "source": "./src/index.ts",
   "types": "./dist/index.d.ts",
   "main": "./dist/index.js",

--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
                     </h1>
                     <ul className="inline-flex gap-4">
                         <li>
-                            <Link query={{}} className="link:underline" href={router.links.index}>
+                            <Link className="link:underline" href={router.links.index}>
                                 Index Page
                             </Link>
                         </li>
@@ -28,7 +28,7 @@ function App() {
                         </li>
 
                         <li>
-                            <Link query={{}} className="link:underline" href={router.links.blog}>
+                            <Link className="link:underline" href={router.links.blog}>
                                 Blog
                             </Link>
                         </li>

--- a/src/router/link.tsx
+++ b/src/router/link.tsx
@@ -4,7 +4,6 @@ import { useBasename, useHref, useNavigation } from "../brouther/brouther";
 import type { Paths } from "../types/paths";
 import type { QueryString } from "../types/query-string";
 import { AnyJson } from "../types";
-import { X } from "../types/x";
 
 const isLeftClick = (e: React.MouseEvent) => e.button === 0;
 
@@ -20,7 +19,7 @@ export type LinkProps<Path extends string> = Omit<
         : { paths?: Paths.Parse<Paths.Pathname<Path>> }) &
     (QueryString.Has<Path> extends false
         ? { query?: undefined }
-        : X.AtLeastOne<QueryString.Parse<Path>> extends true
+        : QueryString.HasRequired<Path> extends true
         ? { query: QueryString.Parse<Path> }
         : { query?: QueryString.Parse<Path> });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,12 +66,12 @@ export type CreateHref<T extends readonly Route[]> = <
 >(
     ...args: Paths.Parse<Path> extends null
         ? QueryString.Has<Path> extends true
-            ? X.AtLeastOne<QueryString.Parse<Path>> extends true
+            ? QueryString.HasRequired<Path> extends true
                 ? readonly [path: Path, qs: Qs, parsers?: QueryStringParsers]
                 : readonly [path: Path, qs?: Qs, parsers?: QueryStringParsers]
             : readonly [path: Path]
         : QueryString.Has<Path> extends true
-        ? X.AtLeastOne<QueryString.Parse<Path>> extends true
+        ? QueryString.HasRequired<Path> extends true
             ? readonly [path: Path, params: Params, qs: Qs, parsers?: QueryStringParsers]
             : readonly [path: Path, params: Params, qs?: Qs, parsers?: QueryStringParsers]
         : readonly [path: Path, params: Paths.Parse<Path>]

--- a/src/types/query-string.ts
+++ b/src/types/query-string.ts
@@ -87,4 +87,6 @@ export namespace QueryString {
         readonly getAll: <K extends keyof T>(name: K) => string[];
         readonly set: <K extends keyof T>(name: K, value: string) => void;
     };
+
+    export type HasRequired<Path extends string> = Has<Path> extends true ? (String.Split<Path, "?">[1] extends `${string}!` ? true : false) : false;
 }

--- a/src/types/x.ts
+++ b/src/types/x.ts
@@ -12,11 +12,10 @@ export namespace X {
     export type Promisify<T> = T | Promise<T>;
 
     export type ReduceKeys<T extends {}, Keys extends List.List, C extends number = 0> = Keys["length"] extends C
-      ? false
-      : T[Keys[C]] extends T[Keys[C]] | undefined
-        ? Object.UnionOf<Keys[C]> extends (undefined|Object.UnionOf<Keys[C]>) ? true : false
+        ? false
+        : T[Keys[C]] extends T[Keys[C]] | undefined
+        ? Object.UnionOf<Keys[C]> extends undefined | Object.UnionOf<Keys[C]>
+            ? true
+            : false
         : ReduceKeys<T, Keys, Number.Add<C, 1>>;
-
-    export type AtLeastOne<T extends {} | null> = T extends null ? false : ReduceKeys<NonNullable<T>, Union.ListOf<T>>;
-
 }


### PR DESCRIPTION
# Context

The `X.AtLeastOne` type causes bugs when you have a query string on your path. Now the namespace `QueryString` have the current parser to check if the string has required query string.