### PR TITLE
fix(lazyRoute): defer dynamic import until route is first used

### DIFF
--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -162,19 +162,24 @@ export const lazyRoute = <
     lazy: LazyLoader,
     options?: Opts
 ) => {
-    const promise = lazy();
+    let promise: Promise<Lazy<Path, RouteData>> | undefined;
+    const load = (): Promise<Lazy<Path, RouteData>> => {
+        if (promise === undefined) promise = Promise.resolve(lazy());
+        return promise;
+    };
     const actions: Actions<Path> = async () => {
-        const r = promise instanceof Promise ? promise.then((x) => x.actions) : promise.actions;
-        const resolved = await r;
-        return resolved?.() as any;
+        const r = await load();
+        return r.actions?.() as any;
     };
     const loader: Loader<Path> = async (args) => {
-        const r = promise instanceof Promise ? promise.then((x) => x.loader) : promise.loader;
-        const resolved = await r;
-        return resolved ? resolved(args) : (undefined as any);
+        const r = await load();
+        return r.loader ? r.loader(args) : (undefined as any);
     };
     const element = React.createElement(
-        React.lazy(async () => (promise instanceof Promise ? promise.then((x) => ({ default: x.default })) : { default: promise.default }))
+        React.lazy(async () => {
+            const r = await load();
+            return { default: r.default };
+        })
     );
     return { ...options, loader, actions, element, path: p } as const;
 };

--- a/tests/lazy-route.test.ts
+++ b/tests/lazy-route.test.ts
@@ -1,0 +1,31 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { jsonResponse } from "../src/brouther/brouther-response";
+import { lazyRoute } from "../src/router/router";
+
+describe("lazyRoute", () => {
+    it("defers loading the route module until loader or actions are used", async () => {
+        const loader = vi.fn(() => jsonResponse({ ok: true }));
+        const action = vi.fn(() => jsonResponse({ ok: true }));
+        const actions = vi.fn(() => ({ post: action }));
+        const loadRoute = vi.fn(async () => ({
+            default: () => React.createElement("div"),
+            loader,
+            actions,
+        }));
+
+        const route = lazyRoute("/lazy", loadRoute);
+
+        expect(loadRoute).not.toHaveBeenCalled();
+
+        await route.loader({} as never);
+
+        expect(loadRoute).toHaveBeenCalledTimes(1);
+        expect(loader).toHaveBeenCalledTimes(1);
+
+        await route.actions();
+
+        expect(loadRoute).toHaveBeenCalledTimes(1);
+        expect(actions).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary

This fixes a production issue identified through Sentry in a UI consuming this library. Sentry reported multiple dynamic import failures during a single app startup/redirect, with unrelated route chunks failing at nearly the same timestamp:

- `lawsuit.page`
- `honorarios.page`
- `import-tasks.page`
- `metrics.page`
- `filter.id.page`

Cloudflare Pages investigation ruled out a deploy-in-progress: the active deployment had completed more than 40 hours before the Sentry event, and the reported chunk files were part of that deployment.

**Root cause:** `lazyRoute` was eagerly executing the provided dynamic import function at route definition time:

```ts
const promise = lazy(); // called immediately, for every route
```

This caused every route chunk to be fetched during router initialization, even when the user only visits one route. Under certain network or CDN conditions this floods the browser with parallel chunk requests, some of which fail.

## Changes

- Defer calling `lazy()` until the route module is actually needed (loader, actions, or React element render)
- Memoize the resulting `Promise` so all three consumers share the same import call
- Narrow `load()` return type to `Promise<Lazy<...>>` by wrapping with `Promise.resolve()`, removing an unnecessary union
- Add regression test proving `lazyRoute` does not invoke the import function at route definition time

## Impact

Reduces startup network load, avoids unrelated route chunk failures, and makes dynamic imports behave according to the expectation implied by the `lazyRoute` name.